### PR TITLE
Feature: Gitea Access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
       - name: Run tests
         run: cargo test
 
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          rust-version: "stable"
+          log-level: error
+          command: check
+
   publish-check:
     name: Publish Check
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/update-available.svg)](https://crates.io/crates/update-available)
 [![Documentation](https://docs.rs/update-available/badge.svg)](https://docs.rs/update-available)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/bircni/update-available/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/bircni/update-available/actions/workflows/ci.yml)
 
 A Rust library to check for updates of crates on crates.io or GitHub repositories. Get notified when newer versions of your dependencies are available with beautiful, formatted output.
 
@@ -22,6 +23,12 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 update-available = "0.1.0"
+```
+
+or use `cargo add`:
+
+```bash
+cargo add update-available
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -54,9 +54,20 @@ match check_github("serde", "serde-rs", "1.0.0") {
 }
 ```
 
-### Convenience function for direct printing
+### Check for Gitea repository updates
 
 ```rust
+use update_available::check_gitea;
+
+match check_gitea("my-repo", "username", "https://gitea.example.com", "1.0.0") {
+    Ok(info) => println!("{}", info),
+    Err(e) => eprintln!("Error: {}", e),
+}
+```
+
+### Convenience function for direct printing
+
+````rust
 use update_available::{print_check, Source};
 
 // Check crates.io and print result
@@ -64,7 +75,12 @@ print_check("serde", "1.0.0", Source::CratesIo);
 
 // Check GitHub and print result
 print_check("my-repo", "0.1.0", Source::Github("username".to_string()));
-```
+
+// Check Gitea and print result
+print_check("my-repo", "0.1.0", Source::Gitea {
+    user: "username".to_string(),
+    base_url: "https://gitea.example.com".to_string(),
+});
 
 ## Example Output
 
@@ -78,7 +94,7 @@ When an update is available, you'll see beautifully formatted output like this:
     • Improved performance by 15%
     • Added new serialization features
 🌐  More info: https://crates.io/crates/example
-```
+````
 
 When you're already using the latest version:
 
@@ -158,4 +174,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - [ ] Async support with `tokio` and `reqwest`
 - [ ] Custom output formatting
-- [ ] Support for other sources (e.g. GitLab, Gitea)
+- [ ] Support for other sources (e.g. GitLab)
+- [x] Support for Gitea repositories

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,16 @@
+[licenses]
+version = 2
+private = { ignore = true }
+confidence-threshold = 0.93 # We want really high confidence when inferring licenses from text
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0"
+]
+exceptions = []
+
+[bans]
+multiple-versions = "allow"

--- a/src/data.rs
+++ b/src/data.rs
@@ -11,7 +11,7 @@ pub(crate) struct UpdateAvailable {
 }
 
 #[derive(Deserialize)]
-pub(crate) struct GithubResponse {
+pub(crate) struct GiteaHubResponse {
     pub(crate) tag_name: String,
     pub(crate) body: Option<String>,
     pub(crate) html_url: String,
@@ -63,14 +63,14 @@ impl UpdateInfo {
         Ok(Self::new(latest_version, &current_version, None, url))
     }
 
-    pub(crate) fn from_github(
-        github_response: GithubResponse,
+    pub(crate) fn from_gitea_or_hub(
+        response: GiteaHubResponse,
         current_version: &str,
     ) -> anyhow::Result<Self> {
-        let latest_version = github_response
+        let latest_version = response
             .tag_name
             .strip_prefix("v")
-            .unwrap_or(&github_response.tag_name);
+            .unwrap_or(&response.tag_name);
         let latest_version = Version::parse(latest_version)
             .map_err(|e| anyhow::anyhow!("Failed to parse latest version: {}", e))?;
         let current_version = Version::parse(current_version)
@@ -78,8 +78,8 @@ impl UpdateInfo {
         Ok(Self::new(
             latest_version,
             &current_version,
-            github_response.body,
-            github_response.html_url,
+            response.body,
+            response.html_url,
         ))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub enum Source {
     CratesIo,
     /// Check for updates on GitHub for a specific user.
     Github(User),
+    /// Check for updates on Gitea for a specific user and Gitea URL.
+    Gitea(User, String),
 }
 
 /// Prints update information for a package from the specified source.
@@ -38,11 +40,18 @@ pub enum Source {
 ///
 /// // Check GitHub
 /// print_check("my-repo", "0.1.0", Source::Github("username".to_string()));
+///
+/// // Check Gitea
+/// print_check("my-repo", "0.1.0", Source::Gitea("username".to_string(), "https://gitea.example.com".to_string()));
 /// ```
 pub fn print_check(name: &str, current_version: &str, source: Source) {
     let result = match source {
         Source::CratesIo => check_crates_io(name, current_version),
         Source::Github(user) => check_github(name, &user, current_version),
+        Source::Gitea(user, gitea_url) => {
+            let update_available = UpdateAvailable::new(name, current_version);
+            update_available.gitea(&user, &gitea_url)
+        }
     };
     if let Ok(info) = result {
         println!("{info}");
@@ -125,4 +134,50 @@ pub fn check_crates_io(name: &str, current_version: &str) -> anyhow::Result<Upda
 pub fn check_github(name: &str, user: &str, current_version: &str) -> anyhow::Result<UpdateInfo> {
     let update_available = UpdateAvailable::new(name, current_version);
     update_available.github(user)
+}
+
+/// Checks for updates on Gitea for the specified repository.
+///
+/// This function queries the Gitea API to check if a newer version
+/// of the specified repository is available.
+///
+/// # Arguments
+///
+/// * `name` - The name of the repository to check
+/// * `user` - The Gitea username or organization that owns the repository
+/// * `gitea_url` - The base URL of the Gitea instance (e.g., <https://gitea.example.com>)
+/// * `current_version` - The current version string (e.g., "1.0.0")
+///
+/// # Returns
+///
+/// Returns a `Result<UpdateInfo, anyhow::Error>` containing update information
+/// if successful, or an error if the check fails.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// * The network request fails
+/// * The Gitea API returns an error
+/// * The version strings cannot be parsed
+/// * The response format is unexpected
+/// * The repository does not exist or has no releases
+///
+/// # Examples
+///
+/// ```rust
+/// use update_available::check_gitea;
+///
+/// match check_gitea("my-repo", "username", "https://gitea.example.com", "1.0.0") {
+///     Ok(info) => println!("{}", info),
+///     Err(e) => eprintln!("Error checking for updates: {}", e),
+/// }
+/// ```
+pub fn check_gitea(
+    name: &str,
+    user: &str,
+    gitea_url: &str,
+    current_version: &str,
+) -> anyhow::Result<UpdateInfo> {
+    let update_available = UpdateAvailable::new(name, current_version);
+    update_available.gitea(user, gitea_url)
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -66,3 +66,13 @@ fn test_print_check_crates_io() {
 fn test_print_check_github() {
     print_check("cargo-wash", "0.1.0", Source::Github("bircni".to_owned()));
 }
+
+#[ignore = "Gitea tests are ignored by default, as they require a valid Gitea URL and user."]
+#[test]
+fn test_print_check_gitea() {
+    print_check(
+        "cargo-wash",
+        "0.1.0",
+        Source::Gitea("bircni".to_owned(), "https://gitea.example.com".to_owned()),
+    );
+}


### PR DESCRIPTION
This pull request introduces support for checking updates from Gitea repositories, alongside several other improvements to the codebase and documentation. The most significant changes include adding a new `Gitea` source to the update-checking functionality, updating the CI pipeline to include a license check with `cargo-deny`, and refining the README to reflect the new Gitea support.

### New Feature: Gitea Support
* Added a new `Gitea` variant to the `Source` enum and implemented corresponding logic for checking updates from Gitea repositories (`src/lib.rs`, `src/logic.rs`). [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R18-R19) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R138-R183) [[3]](diffhunk://#diff-a6cb179990b1385f22b83418bfeaffa68f9b62ef16be1969dd66ee79c19e2b02L43-R70)
* Updated the `UpdateAvailable` struct to support both Gitea and GitHub responses by introducing a unified `GiteaHubResponse` struct (`src/data.rs`). [[1]](diffhunk://#diff-4211452d969b5448e71fcba1556be774be01fa22f3558df4dda723c1a2bdcd6fL14-R14) [[2]](diffhunk://#diff-4211452d969b5448e71fcba1556be774be01fa22f3558df4dda723c1a2bdcd6fL66-R82)
* Added a test for the Gitea update-checking functionality, marked as ignored by default due to external dependencies (`src/test.rs`).

### CI Pipeline Enhancement
* Introduced a `cargo-deny` job in the CI workflow to ensure license compliance. Configured license rules in a new `deny.toml` file (`.github/workflows/ci.yml`, `deny.toml`). [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR53-R63) [[2]](diffhunk://#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3deR1-R16)

### Documentation Updates
* Updated the README to include examples and descriptions for the new Gitea support, replacing the placeholder for "other sources" with Gitea-specific details (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R83) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L161-R178)
* Fixed formatting issues in the example output section of the README (`README.md`).

### Code Refactoring
* Renamed `GithubResponse` to `GiteaHubResponse` for broader applicability and updated related methods to handle both Gitea and GitHub responses (`src/data.rs`, `src/logic.rs`). [[1]](diffhunk://#diff-4211452d969b5448e71fcba1556be774be01fa22f3558df4dda723c1a2bdcd6fL14-R14) [[2]](diffhunk://#diff-a6cb179990b1385f22b83418bfeaffa68f9b62ef16be1969dd66ee79c19e2b02L3-R3)

These changes enhance the library's functionality by adding support for a new source (Gitea), improving CI practices, and ensuring the documentation is up-to-date and user-friendly.